### PR TITLE
update parts-of structure

### DIFF
--- a/curveship.js
+++ b/curveship.js
@@ -181,9 +181,7 @@ class Thing extends Existent {
     this.parent = actor.cosmos;
   }
   setParts(parts) {
-    console.log(parts);
     for (var existent of parts) {
-      console.log(existent);
       existent.parent = this;
     }
   }
@@ -335,7 +333,6 @@ class Narrator {
     exTag = exTag == null ? ex.tag  : exTag;
     if (this.names[exTag].nameByClass) {
       let className = this.names[ex.getClass().tag];
-      //console.log(className);
       this.names[exTag] = new Names("a " + className.name, "the " + className.name);
     }
     if (this.names[exTag].pronouns !== null || ex.hasOwnProperty("gender")) {
@@ -381,7 +378,6 @@ class Narrator {
       superClasses.reverse();
       exCategories.push(superClasses);
     }
-    console.log(exCategories);
     let minLength = Math.min(...exCategories.map(item => item.length));
     var superClass = null;
     for(var i = 0; i < minLength; i++) {
@@ -403,15 +399,13 @@ class Narrator {
       classes.push(elem.getClass());
       parents.push(elem);
     }
-    var superPart = this.traverseRelationTree(parents);
-    console.log("super part");
-    console.log(superPart);
-    var superClass = this.traverseRelationTree(classes);
+    var superPart = this.traverseRelationTree(parents); //check for object relation (eg "part of")
+    var superClass = this.traverseRelationTree(classes); //check for category relations
 
     if(superPart != actor.cosmos) return (ex.length() == 1) ? "the part of the " + superPart.tag : " the parts of the " + superPart.tag;
     if(superClass !== null) return this.name(superClass, "category", ex.tag);
     
-    var initClass = ex.existentArray[0].getClass();
+    var initClass = ex.existentArray[0].getClass(); //check for property relations
     var initProperties = initClass.getProperties();
     for (var property of initProperties.keys()) {
       var shareAllProperties = ex.existentArray.every(item => item.getClass().getProperties().has(property));
@@ -419,6 +413,7 @@ class Narrator {
         return "the objects with " + property;
       }
     }
+
     return null;
   }
 

--- a/curveship.js
+++ b/curveship.js
@@ -179,10 +179,11 @@ class Thing extends Existent {
     this.spatialRelation = spatialRelation;
     this.spatialParent = spatialParent;
     this.parent = actor.cosmos;
-    console.log(this.parent);
   }
   setParts(parts) {
+    console.log(parts);
     for (var existent of parts) {
+      console.log(existent);
       existent.parent = this;
     }
   }
@@ -334,7 +335,7 @@ class Narrator {
     exTag = exTag == null ? ex.tag  : exTag;
     if (this.names[exTag].nameByClass) {
       let className = this.names[ex.getClass().tag];
-      console.log(className);
+      //console.log(className);
       this.names[exTag] = new Names("a " + className.name, "the " + className.name);
     }
     if (this.names[exTag].pronouns !== null || ex.hasOwnProperty("gender")) {
@@ -380,6 +381,7 @@ class Narrator {
       superClasses.reverse();
       exCategories.push(superClasses);
     }
+    console.log(exCategories);
     let minLength = Math.min(...exCategories.map(item => item.length));
     var superClass = null;
     for(var i = 0; i < minLength; i++) {
@@ -390,24 +392,23 @@ class Narrator {
         break;
       }
     }
-    return null;
+    return superClass;
   }
 
   findSimilarities(ex) {
     var exCategories = [];
-    var initParent = ex.existentArray[0].parent;
-    var isAllParts = ex.existentArray.every(item => item.parent == initParent);
-    if (isAllParts) {
-      return (ex.length() == 1) ? "the part of the " + initParent.tag : " the parts of the " + initParent.tag;
-    }
-    classes = []
-    //parents = []
-    for (elem of ex.existentArray) {
+    var classes = []
+    var parents = []
+    for (var elem of ex.existentArray) {
       classes.push(elem.getClass());
-      //relations.push(elem);
+      parents.push(elem);
     }
-    superClass = traverseRelationTree(classes);
+    var superPart = this.traverseRelationTree(parents);
+    console.log("super part");
+    console.log(superPart);
+    var superClass = this.traverseRelationTree(classes);
 
+    if(superPart != actor.cosmos) return (ex.length() == 1) ? "the part of the " + superPart.tag : " the parts of the " + superPart.tag;
     if(superClass !== null) return this.name(superClass, "category", ex.tag);
     
     var initClass = ex.existentArray[0].getClass();

--- a/curveship.js
+++ b/curveship.js
@@ -174,10 +174,17 @@ class Place extends Existent {
 var place = {};
 
 class Thing extends Existent {
-  constructor(spatialRelation = "in", parent = actor.cosmos) {
+  constructor(spatialRelation = "in", spatialParent = actor.cosmos) {
     super();
     this.spatialRelation = spatialRelation;
-    this.parent = parent;
+    this.spatialParent = spatialParent;
+    this.parent = actor.cosmos;
+    console.log(this.parent);
+  }
+  setParts(parts) {
+    for (var existent of parts) {
+      existent.parent = this;
+    }
   }
 }
 
@@ -338,15 +345,10 @@ class Narrator {
     }
   }
 
-  findSimilarities(ex) {
+  traverseRelationTree(relations) {
     var exCategories = [];
-    var initParent = ex.existentArray[0].parent;
-    var isAllParts = ex.existentArray.every(item => item.spatialRelation == spatial.part_of && item.parent == initParent);
-    if (isAllParts) {
-      return (ex.length() == 1) ? "the part of the " + initParent.tag : " the parts of the " + initParent.tag;
-    }
-    for (var item of ex.existentArray) {
-      var basicClass = item.getClass();
+    for (var relation of relations) {
+      var basicClass = relation;
       var superClasses = [];
       while (basicClass !== category.existent) { // TODO you can chose to stop at some level of the tree using this predicate
         superClasses.push(basicClass);
@@ -365,6 +367,23 @@ class Narrator {
         break;
       }
     }
+    return null;
+  }
+
+  findSimilarities(ex) {
+    var exCategories = [];
+    var initParent = ex.existentArray[0].parent;
+    var isAllParts = ex.existentArray.every(item => item.parent == initParent);
+    if (isAllParts) {
+      return (ex.length() == 1) ? "the part of the " + initParent.tag : " the parts of the " + initParent.tag;
+    }
+    classes = []
+    //parents = []
+    for (elem of ex.existentArray) {
+      classes.push(elem.getClass());
+      //relations.push(elem);
+    }
+    superClass = traverseRelationTree(classes);
 
     if(superClass !== null) return this.name(superClass, "category");
     
@@ -543,6 +562,10 @@ var spatial = { // Maps an abstract spatial relationship to a preposition
   worn_by: "worn by",
   part_of: "part of"
 };
+
+var relation = {
+  part_of: "part of"
+}
 
 var temporal = { // Maps an abstract temporal relationship to a preposition
   at: "at",

--- a/curveship.js
+++ b/curveship.js
@@ -178,7 +178,7 @@ class Thing extends Existent {
     super();
     this.spatialRelation = spatialRelation;
     this.spatialParent = spatialParent;
-    this.parent = actor.cosmos;
+    this.parent = actor.cosmos; //note that this is the "part of" parent — probably not the best naming, but used now b/c of traverseRelationTree refactoring
   }
   setParts(parts) {
     for (var existent of parts) {
@@ -393,8 +393,8 @@ class Narrator {
 
   findSimilarities(ex) {
     var exCategories = [];
-    var classes = []
-    var parents = []
+    var classes = [];
+    var parents = [];
     for (var elem of ex.existentArray) {
       classes.push(elem.getClass());
       parents.push(elem);

--- a/examples/bike/index.html
+++ b/examples/bike/index.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <title>A Curveship Story</title>
+    <link rel="StyleSheet" href="../examples.css"/>
+    <script src="../../curveship.js"></script>
+    <script src="../../verb.js"></script>
+    <script src="story.js"></script>
+    <script src="narrator.js"></script>
+</head>
+<body onload="run()">
+  <div id="narrative"></div>
+</body>
+</html>

--- a/examples/bike/narrator.js
+++ b/examples/bike/narrator.js
@@ -1,0 +1,33 @@
+// Casual Narrator for the Simulated Bank Robbery - a Curveship-js example
+//  Copyright 2021 Nick Montfort
+//
+// Copying and distribution of this file, with or without modification,
+// are permitted in any medium without royalty provided the copyright
+// notice and this notice are preserved. This file is offered as-is,
+// without any warranty.
+//
+// Adapted from the original Curveship, now called Curveship-py 0.6.
+
+var spin = {};
+
+let told_by = "a casual, very oblique narrator";
+
+names = {};
+
+names.bike = new Names("the bike");
+
+names.tire = new Names("the tire");
+names.handlebar = new Names("the handlebar");
+names.seat = new Names("the seat");
+
+names.man = new Names("the man");
+names.apple = new Names("the apple")
+
+vp = {};
+
+vp.see1 = new VerbPh("see");
+vp.see2 = new VerbPh("see");
+vp.see3 = new VerbPh("see");
+
+
+function run() { narrate(title, told_by, world, spin, names, vp); }

--- a/examples/bike/story.js
+++ b/examples/bike/story.js
@@ -1,0 +1,39 @@
+// The Simulated Bank Robbery - a Curveship-js example
+//  Copyright 2021 Nick Montfort
+//
+// Copying and distribution of this file, with or without modification,
+// are permitted in any medium without royalty provided the copyright
+// notice and this notice are preserved. This file is offered as-is,
+// without any warranty.
+//
+// Adapted from the original Curveship, now called Curveship-py.
+
+let title = "Bike";
+
+// EXISTENTS: Places, Actors, Things in that order
+
+place.street = new Place();
+
+actor.man = new Actor(spatial.in, place.street, "male");
+
+thing.bike = new Thing(spatial.in, place.street);
+thing.tire = new Thing(spatial.in, place.street);
+thing.handlebar = new Thing(spatial.in, place.street);
+thing.seat = new Thing(spatial.in, place.street);
+thing.shell = new Thing(spatial.in, place.street);
+thing.cover = new Thing(spatial.in, place.street);
+
+
+thing.bike.setParts([thing.tire, thing.handlebar, thing.seat]);
+thing.seat.setParts([thing.shell, thing.cover]);
+
+
+
+// EVENTS
+
+ev.see1 = new Event(actor.man, thing.bike);
+ev.see2 = new Event(actor.man, [thing.tire, thing.seat, thing.handlebar, thing.shell]);
+ev.see3 = new Event(actor.man, [thing.shell, thing.cover]);
+
+
+var world = new World(place, actor, category, thing, ev);


### PR DESCRIPTION
* refactored previous code for category naming to generalize for parts-of and hopefully (?) other things too
* added example file to show how setting parts work
essentially:
thing.a = ...
thing.b = ...
thing.c = ...
thing.c.setParts(thing.a, thing.b)
* to-consider:
* grouping by parts and categories are currently controlled by the groupBySimilarity flag — should they be separate?
* right now, parts is attempted before categories — if there's a possible grouping by parts and categories, is this the correct prioritization?